### PR TITLE
Add support for cmd with the same command as the alias

### DIFF
--- a/alf
+++ b/alf
@@ -91,14 +91,17 @@ generate() {
       if [[ -z $indent ]]; then
         ali1="${BASH_REMATCH[2]}"
         cmd1="${BASH_REMATCH[3]}"
-        unset ali2
-        unset cmd2
+        local_regex="^$ali1(\s+|$)"
+        if [[ $cmd1 =~ $local_regex ]]; then
+          cmd1="command $cmd1"
+        fi
+        unset ali2 cmd2
         generate_last_cmd
         lastcmd=$cmd1
       else
         ali2="${BASH_REMATCH[2]}"
         cmd2="${BASH_REMATCH[3]}"
-      fi    
+      fi
 
       if [[ -n $ali2 ]]; then
         echo "  $cond [[ \$1 = \"$ali2\" ]]; then"

--- a/test/fixtures/generate/alf.conf
+++ b/test/fixtures/generate/alf.conf
@@ -14,3 +14,8 @@ g: git
 # Reuse:
 # You can call an alias from another alias
 gg: g p
+
+ag: ag --color
+
+abc: abc
+  help: --help

--- a/test/fixtures/generate/aliases.txt
+++ b/test/fixtures/generate/aliases.txt
@@ -21,3 +21,16 @@ g() {
 gg() {
   g p "$@"
 }
+
+ag() {
+  command ag --color "$@"
+}
+
+abc() {
+  if [[ $1 = "help" ]]; then
+    shift
+    command abc --help "$@"
+  else
+    command abc "$@"
+  fi
+}

--- a/test/fixtures/generate/output1.txt
+++ b/test/fixtures/generate/output1.txt
@@ -21,3 +21,16 @@ g() {
 gg() {
   g p "$@"
 }
+
+ag() {
+  command ag --color "$@"
+}
+
+abc() {
+  if [[ $1 = "help" ]]; then
+    shift
+    command abc --help "$@"
+  else
+    command abc "$@"
+  fi
+}


### PR DESCRIPTION
Before this patch, the below would cause an endless loop:

```
ls: ls -la
```

We now check for such cases, and add `command` in front of the command.