### PR TITLE
Add escape character

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ place it somewhere in your path, and make it executable.
 ### 2. Create your own `alf-conf` repository  
 
 The easiest way to use alf is to create a repository on github, call it 
-`alf-conf`, and put an `alf.conf` file in it. See the [`alf.conf`](alf.conf)
-file as a starting point, or fork my [alf-conf][conf] repository.
+`alf-conf`, and put an `alf.conf` file in it.
+
+- See the [alf.conf](alf.conf) file as a starting point, or
+- Fork my [alf-conf][conf] repository
 
 ### 3. Connect alf to your repository
 

--- a/alf
+++ b/alf
@@ -127,10 +127,17 @@ generate() {
       if [[ -n $ali2 ]]; then
         echo "  $cond [[ \$1 = \"$ali2\" ]]; then"
         echo "    shift"
-        if [[ $cmd2 =~ \$ ]]; then
-          echo "    $cmd1 $cmd2"
+        
+        if [[ $cmd2 =~ ^! ]]; then
+          cmd=${cmd2:1}
         else
-          echo "    $cmd1 $cmd2 \"\$@\""
+          cmd="$cmd1 $cmd2"
+        fi
+
+        if [[ $cmd2 =~ \$ ]]; then
+          echo "    $cmd"
+        else
+          echo "    $cmd \"\$@\""
         fi
         cond="elif"
       else
@@ -261,7 +268,11 @@ show() {
       if [[ $line =~ $regex2 ]]; then
         if [[ $line =~ $regex3 ]]; then
           cmd2="${BASH_REMATCH[3]}"
-          echo "$cmd1 $cmd2"
+          # if [[ $cmd2 =~ ^! ]]; then
+          #   echo ${cmd2:1}
+          # else
+            echo "$cmd1 $cmd2"
+          # fi
           exit 0
         fi
       else

--- a/alf
+++ b/alf
@@ -268,11 +268,11 @@ show() {
       if [[ $line =~ $regex2 ]]; then
         if [[ $line =~ $regex3 ]]; then
           cmd2="${BASH_REMATCH[3]}"
-          # if [[ $cmd2 =~ ^! ]]; then
-          #   echo ${cmd2:1}
-          # else
+          if [[ $cmd2 =~ ^! ]]; then
+            echo ${cmd2:1}
+          else
             echo "$cmd1 $cmd2"
-          # fi
+          fi
           exit 0
         fi
       else

--- a/alf.conf
+++ b/alf.conf
@@ -14,3 +14,10 @@ g: git
 # Reuse:
 # You can call an alias from another alias
 gg: g p
+
+# Escape code:
+# Sub commands that start with an exclamation mark will not be prefixed
+# by their parent command
+dc: docker-compose
+  deploy: !docker stack deploy -c docker-compose.yml
+  upd: up -d

--- a/test/config/cucumber.yml
+++ b/test/config/cucumber.yml
@@ -1,11 +1,9 @@
 <%
   rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
   rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-  std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
+  std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict"
 %>
 
 # The -q was added manually by DannyB.
 default: -q <%= std_opts %> features
-wip:     --tags @wip:3 --wip features
 current: -s <%= std_opts %> --tags @current features
-rerun:   <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip

--- a/test/features/which.feature
+++ b/test/features/which.feature
@@ -28,3 +28,8 @@ Scenario: Run alf which CODE SUBCODE with invalid code
    When I run "alf which g no"
    Then the output should say "Error: No such alias: g no"
     And the exit code should mean failure
+
+Scenario: Run alf which CODE SUBCODE with escaped code
+   When I run "alf which dc deploy"
+   Then the output should say "docker stack deploy -c docker-compose.yml"
+    And the exit code should mean success

--- a/test/features/which.feature
+++ b/test/features/which.feature
@@ -31,5 +31,5 @@ Scenario: Run alf which CODE SUBCODE with invalid code
 
 Scenario: Run alf which CODE SUBCODE with escaped code
    When I run "alf which dc deploy"
-   Then the output should say "docker stack deploy -c docker-compose.yml"
+   Then the output should match "^docker stack deploy -c docker-compose.yml$"
     And the exit code should mean success

--- a/test/fixtures/generate/alf.conf
+++ b/test/fixtures/generate/alf.conf
@@ -20,9 +20,14 @@ ag: ag --color
 abc: abc
   help: --help
 
-
 # Test positionals
 reverse: echo $2 $1
 
 say: echo
   again: $1 $1
+
+# Test escape operator (!)
+dc: docker-compose
+  ls: config --services
+  deploy: !docker stack deploy -c docker-compose.yml
+  upd: up -d

--- a/test/fixtures/generate/aliases.txt
+++ b/test/fixtures/generate/aliases.txt
@@ -56,3 +56,19 @@ say() {
     echo "$@"
   fi
 }
+
+unalias dc 1>/dev/null 2>&1
+dc() {
+  if [[ $1 = "ls" ]]; then
+    shift
+    docker-compose config --services "$@"
+  elif [[ $1 = "deploy" ]]; then
+    shift
+    docker stack deploy -c docker-compose.yml "$@"
+  elif [[ $1 = "upd" ]]; then
+    shift
+    docker-compose up -d "$@"
+  else
+    docker-compose "$@"
+  fi
+}

--- a/test/fixtures/generate/output1.txt
+++ b/test/fixtures/generate/output1.txt
@@ -56,3 +56,19 @@ say() {
     echo "$@"
   fi
 }
+
+unalias dc 1>/dev/null 2>&1
+dc() {
+  if [[ $1 = "ls" ]]; then
+    shift
+    docker-compose config --services "$@"
+  elif [[ $1 = "deploy" ]]; then
+    shift
+    docker stack deploy -c docker-compose.yml "$@"
+  elif [[ $1 = "upd" ]]; then
+    shift
+    docker-compose up -d "$@"
+  else
+    docker-compose "$@"
+  fi
+}


### PR DESCRIPTION
This PR enables the use of an exclamation mark to prefix sub commands, in order to "escape" their parent command. A nice use case for this functionality, is to add functionality to a command by using another.

For instance, the below adds a `deploy` command to `docker-compose`, which is facilitated by `docker stack` and does not actually exist in `docker-compose`:

```yaml
# alf.conf
dc: docker-compose
  deploy: !docker stack deploy -c docker-compose.yml
  upd: up -d
```