### PR TITLE
Usage updates

### DIFF
--- a/alf
+++ b/alf
@@ -18,7 +18,7 @@ alf_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  alf [command] [options]\n"
+  printf "  alf [command]\n"
   printf "  alf [command] --help | -h\n"
   printf "  alf --version | -v\n"
   echo
@@ -49,12 +49,7 @@ alf_usage() {
     
     # :environment_variable.usage
     echo "  ALF_RC_FILE"
-    printf "    Path to alfrc file\n    This file holds the location of the alf-conf repository\n    Default: ~/.alfrc\n"
-    echo
-    
-    # :environment_variable.usage
-    echo "  ALF_ALIASES_FILE"
-    printf "    Path to bash_aliases file\n    This file will be generated when calling 'alf save'\n    Default: ~/.bash_aliases\n"
+    printf "    Path to alfrc file\n    This file holds the path to the alf-conf repository\n    Default: ~/.alfrc\n"
     echo
 
   fi
@@ -121,7 +116,7 @@ alf_download_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  alf download [options]\n"
+  printf "  alf download\n"
   printf "  alf download --help | -h\n"
   echo
 
@@ -149,7 +144,7 @@ alf_upload_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  alf upload [options]\n"
+  printf "  alf upload\n"
   printf "  alf upload --help | -h\n"
   echo
 
@@ -177,7 +172,7 @@ alf_generate_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  alf generate [options]\n"
+  printf "  alf generate\n"
   printf "  alf generate --help | -h\n"
   echo
 
@@ -205,7 +200,7 @@ alf_save_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  alf save [options]\n"
+  printf "  alf save\n"
   printf "  alf save --help | -h\n"
   echo
 
@@ -214,6 +209,14 @@ alf_save_usage() {
     # :command.usage_fixed_flags
     echo "  --help, -h"
     printf "    Show this help\n"
+    echo
+
+    # :command.usage_environment_variables
+    printf "Environment Variables:\n"
+    
+    # :environment_variable.usage
+    echo "  ALF_ALIASES_FILE"
+    printf "    Path to bash_aliases file\n    Aliases will be saved to this file\n    Default: ~/.bash_aliases\n"
     echo
 
   fi
@@ -233,7 +236,7 @@ alf_edit_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  alf edit [options]\n"
+  printf "  alf edit\n"
   printf "  alf edit --help | -h\n"
   echo
 
@@ -261,7 +264,7 @@ alf_which_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  alf which CODE [SUBCODE] [options]\n"
+  printf "  alf which CODE [SUBCODE]\n"
   printf "  alf which --help | -h\n"
   echo
 
@@ -299,7 +302,7 @@ alf_upgrade_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  alf upgrade [options]\n"
+  printf "  alf upgrade\n"
   printf "  alf upgrade --help | -h\n"
   echo
 
@@ -1010,7 +1013,7 @@ alf_which_parse_requirements() {
     args[code]=$1
     shift
   else
-    printf "missing required argument: CODE\nusage: alf which CODE [SUBCODE] [options]\n"
+    printf "missing required argument: CODE\nusage: alf which CODE [SUBCODE]\n"
     exit 1
   fi
   # :command.required_flags_filter

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -6,14 +6,8 @@ environment_variables:
 - name: alf_rc_file
   help: |
     Path to alfrc file
-    This file holds the location of the alf-conf repository
+    This file holds the path to the alf-conf repository
     Default: ~/.alfrc
-
-- name: alf_aliases_file
-  help: |
-    Path to bash_aliases file
-    This file will be generated when calling 'alf save'
-    Default: ~/.bash_aliases
 
 commands:
 - name: connect
@@ -55,6 +49,13 @@ commands:
 - name: save
   short: s
   help: Generate aliases to ~/.bash_aliases
+
+  environment_variables:
+  - name: alf_aliases_file
+    help: |
+      Path to bash_aliases file
+      Aliases will be saved to this file
+      Default: ~/.bash_aliases
 
 - name: edit
   short: e

--- a/test/approvals/alf_download_help
+++ b/test/approvals/alf_download_help
@@ -3,7 +3,7 @@ alf download - Perform git pull on the connected repo
 Shortcut: d
 
 Usage:
-  alf download [options]
+  alf download
   alf download --help | -h
 
 Options:

--- a/test/approvals/alf_generate_help
+++ b/test/approvals/alf_generate_help
@@ -3,7 +3,7 @@ alf generate - Generate aliases to stdout
 Shortcut: g
 
 Usage:
-  alf generate [options]
+  alf generate
   alf generate --help | -h
 
 Options:

--- a/test/approvals/alf_save_help
+++ b/test/approvals/alf_save_help
@@ -3,9 +3,15 @@ alf save - Generate aliases to ~/.bash_aliases
 Shortcut: s
 
 Usage:
-  alf save [options]
+  alf save
   alf save --help | -h
 
 Options:
   --help, -h
     Show this help
+
+Environment Variables:
+  ALF_ALIASES_FILE
+    Path to bash_aliases file
+    Aliases will be saved to this file
+    Default: ~/.bash_aliases

--- a/test/approvals/alf_upload_help
+++ b/test/approvals/alf_upload_help
@@ -3,7 +3,7 @@ alf upload - Perform git commit and push on the connected repo
 Shortcut: u
 
 Usage:
-  alf upload [options]
+  alf upload
   alf upload --help | -h
 
 Options:

--- a/test/fixtures/empty-dir/approvals/alf
+++ b/test/fixtures/empty-dir/approvals/alf
@@ -1,7 +1,7 @@
 alf - Your Little Bash Alias Friend
 
 Usage:
-  alf [command] [options]
+  alf [command]
   alf [command] --help | -h
   alf --version | -v
 

--- a/test/fixtures/empty-dir/approvals/alf_help
+++ b/test/fixtures/empty-dir/approvals/alf_help
@@ -1,7 +1,7 @@
 alf - Your Little Bash Alias Friend
 
 Usage:
-  alf [command] [options]
+  alf [command]
   alf [command] --help | -h
   alf --version | -v
 
@@ -25,10 +25,5 @@ Options:
 Environment Variables:
   ALF_RC_FILE
     Path to alfrc file
-    This file holds the location of the alf-conf repository
+    This file holds the path to the alf-conf repository
     Default: ~/.alfrc
-
-  ALF_ALIASES_FILE
-    Path to bash_aliases file
-    This file will be generated when calling 'alf save'
-    Default: ~/.bash_aliases

--- a/test/fixtures/empty-dir/approvals/alf_upgrade_help
+++ b/test/fixtures/empty-dir/approvals/alf_upgrade_help
@@ -1,7 +1,7 @@
 alf upgrade - Upgrade alf to the latest version
 
 Usage:
-  alf upgrade [options]
+  alf upgrade
   alf upgrade --help | -h
 
 Options:

--- a/test/fixtures/generate/approvals/alf_which
+++ b/test/fixtures/generate/approvals/alf_which
@@ -1,2 +1,2 @@
 missing required argument: CODE
-usage: alf which CODE [SUBCODE] [options]
+usage: alf which CODE [SUBCODE]

--- a/test/fixtures/generate/approvals/alf_which_help
+++ b/test/fixtures/generate/approvals/alf_which_help
@@ -3,7 +3,7 @@ alf which - Show the alias command
 Shortcut: w
 
 Usage:
-  alf which CODE [SUBCODE] [options]
+  alf which CODE [SUBCODE]
   alf which --help | -h
 
 Options:

--- a/test/fixtures/sample/approvals/alf_edit_help
+++ b/test/fixtures/sample/approvals/alf_edit_help
@@ -3,7 +3,7 @@ alf edit - Open your alf.conf for editing
 Shortcut: e
 
 Usage:
-  alf edit [options]
+  alf edit
   alf edit --help | -h
 
 Options:


### PR DESCRIPTION
- Move the usage help for `ALF_ALIASES_FILE` into the `save` command, since it is the only one using it
- Regenerate with bashly 0.3.8, which removes the `[options]` usage marker unless a command has flags