### PR TITLE
Add support for ZSH

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,7 @@ jobs:
       run: docker-compose build
 
     - name: Run approval tests
-      run: docker-compose run ci
+      run: |
+        docker-compose run ci
+        docker-compose run ci_zsh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,5 @@ jobs:
       run: docker-compose run ci
 
     - name: Run sanity test in zsh
-      run: docker-compose run ci_zsh
+      run: docker-compose run test_zsh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,8 @@ jobs:
       run: docker-compose build
 
     - name: Run approval tests
-      run: |
-        docker-compose run ci
-        docker-compose run ci_zsh
+      run: docker-compose run ci
+
+    - name: Run sanity test in zsh
+      run: docker-compose run ci_zsh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk --no-cache add bash git diffutils grep curl
+RUN apk --no-cache add bash git diffutils grep curl zsh
 
 ENV PS1 "\n\n>> alf \W \$ "
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Features
 - Does not alter anything in your system except for creating the
   `~/.bash_aliases` file, which is normally already sourced by your login
   process.
+- Works with bash and zsh.
 
 Demo
 --------------------------------------------------
@@ -137,6 +138,22 @@ rm -f ~/.alfrc
 
 # Remove .bash_aliases (exists only if you have performed `alf save`)
 rm -f ~/.bash_aliases
+```
+
+
+Compatibility
+--------------------------------------------------
+
+Alf was tested on **bash** and **zsh** (and might work with other shells).
+
+In all cases, bash version 4.0 or higher must be installed, since alf uses
+associative arrays which are not available in older versions.
+
+If your shell does not automatically source `~/.bash_aliases` on startup, you
+should add this line to your startup script:
+
+```shell
+source ~/.bash_aliases
 ```
 
 

--- a/alf
+++ b/alf
@@ -359,12 +359,7 @@ generate_completions() {
   find_config
 
   echo "# Completions"
-
-  if is_zsh; then
-    echo "autoload -U +X compinit && compinit"
-    echo "autoload -U +X bashcompinit && bashcompinit"
-    echo ""
-  fi
+  echo "(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit"
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ $line =~ $ali1_regex ]]; then
@@ -469,11 +464,6 @@ generate_last_cmd() {
       cond="if"
     fi
   fi
-}
-
-# :src/lib/is_zsh.sh
-is_zsh() {
-  pgrep zsh > /dev/null
 }
 
 # :src/lib/save_config.sh

--- a/alf
+++ b/alf
@@ -359,7 +359,7 @@ generate_completions() {
   find_config
 
   echo "# Completions"
-  echo "(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit"
+  echo '(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit'
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ $line =~ $ali1_regex ]]; then

--- a/alf
+++ b/alf
@@ -360,6 +360,12 @@ generate_completions() {
 
   echo "# Completions"
 
+  if is_zsh; then
+    echo "autoload -U +X compinit && compinit"
+    echo "autoload -U +X bashcompinit && bashcompinit"
+    echo ""
+  fi
+
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ $line =~ $ali1_regex ]]; then
       ali="${BASH_REMATCH[1]}"
@@ -463,6 +469,11 @@ generate_last_cmd() {
       cond="if"
     fi
   fi
+}
+
+# :src/lib/is_zsh.sh
+is_zsh() {
+  ps | grep zsh > /dev/null
 }
 
 # :src/lib/save_config.sh

--- a/alf
+++ b/alf
@@ -473,7 +473,7 @@ generate_last_cmd() {
 
 # :src/lib/is_zsh.sh
 is_zsh() {
-  ps | grep zsh > /dev/null
+  pgrep zsh > /dev/null
 }
 
 # :src/lib/save_config.sh

--- a/alf
+++ b/alf
@@ -359,6 +359,7 @@ generate_completions() {
   find_config
 
   echo "# Completions"
+  # shellcheck disable=SC2016
   echo '[[ -n $ZSH_VERSION ]] && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit'
 
   while IFS= read -r line || [ -n "$line" ]; do

--- a/alf
+++ b/alf
@@ -359,7 +359,7 @@ generate_completions() {
   find_config
 
   echo "# Completions"
-  echo '(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit'
+  echo '[[ -n $ZSH_VERSION ]] && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit'
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ $line =~ $ali1_regex ]]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3'
 
 services:
-  # docker-compose run bash
   bash:
     build: .
     <<: &default
@@ -16,7 +15,6 @@ services:
       PS1: "zsh %/ $$ "
     entrypoint: zsh
 
-  # docker-compose run test
   # TEST=connect docker-compose run test
   test: &test
     <<: *default
@@ -29,8 +27,11 @@ services:
     <<: *zsh
     command: test/approve_zsh
 
-  # docker-compose run ci
   ci:
     <<: *test
+    volumes: []
+
+  ci_zsh:
+    <<: *zsh
     volumes: []
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment: { TEST }
     command: test/approve
 
-  test_zsh:
+  test_zsh: &test_zsh
     <<: *zsh
     command: test/approve_zsh
 
@@ -32,6 +32,6 @@ services:
     volumes: []
 
   ci_zsh:
-    <<: *zsh
+    <<: *test_zsh
     volumes: []
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,3 @@ services:
     <<: *test
     volumes: []
 
-  ci_zsh:
-    <<: *test_zsh
-    volumes: []
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,19 @@ version: '3'
 
 services:
   # docker-compose run bash
-  bash: &default
+  bash:
     build: .
-    image: dannyben/alf
-    volumes: 
-    - .:/app
-    - ./alf:/usr/local/bin/alf
+    <<: &default
+      image: dannyben/alf
+      volumes: 
+      - .:/app
+      - ./alf:/usr/local/bin/alf
+
+  zsh: &zsh
+    <<: *default
+    environment:
+      PS1: "zsh %/ $$ "
+    entrypoint: zsh
 
   # docker-compose run test
   # TEST=connect docker-compose run test
@@ -16,7 +23,11 @@ services:
     volumes: 
     - .:/app
     environment: { TEST }
-    command: bash test/approve
+    command: test/approve
+
+  test_zsh:
+    <<: *zsh
+    command: test/approve_zsh
 
   # docker-compose run ci
   ci:

--- a/op.conf
+++ b/op.conf
@@ -1,4 +1,7 @@
-test: docker-compose build test && docker-compose run --rm test
+test: \
+  docker-compose build test && \
+  docker-compose run --rm test && \
+  docker-compose run --rm test_zsh
 #? run test suite inside a docker container
 
 shellcheck: shellcheck alf

--- a/src/lib/generate_completion.sh
+++ b/src/lib/generate_completion.sh
@@ -4,6 +4,7 @@ generate_completions() {
   find_config
 
   echo "# Completions"
+  # shellcheck disable=SC2016
   echo '[[ -n $ZSH_VERSION ]] && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit'
 
   while IFS= read -r line || [ -n "$line" ]; do

--- a/src/lib/generate_completion.sh
+++ b/src/lib/generate_completion.sh
@@ -4,7 +4,7 @@ generate_completions() {
   find_config
 
   echo "# Completions"
-  echo '(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit'
+  echo '[[ -n $ZSH_VERSION ]] && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit'
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ $line =~ $ali1_regex ]]; then

--- a/src/lib/generate_completion.sh
+++ b/src/lib/generate_completion.sh
@@ -5,6 +5,12 @@ generate_completions() {
 
   echo "# Completions"
 
+  if is_zsh; then
+    echo "autoload -U +X compinit && compinit"
+    echo "autoload -U +X bashcompinit && bashcompinit"
+    echo ""
+  fi
+
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ $line =~ $ali1_regex ]]; then
       ali="${BASH_REMATCH[1]}"

--- a/src/lib/generate_completion.sh
+++ b/src/lib/generate_completion.sh
@@ -4,7 +4,7 @@ generate_completions() {
   find_config
 
   echo "# Completions"
-  echo "(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit"
+  echo '(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit'
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ $line =~ $ali1_regex ]]; then

--- a/src/lib/generate_completion.sh
+++ b/src/lib/generate_completion.sh
@@ -4,12 +4,7 @@ generate_completions() {
   find_config
 
   echo "# Completions"
-
-  if is_zsh; then
-    echo "autoload -U +X compinit && compinit"
-    echo "autoload -U +X bashcompinit && bashcompinit"
-    echo ""
-  fi
+  echo "(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit"
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ $line =~ $ali1_regex ]]; then

--- a/src/lib/is_zsh.sh
+++ b/src/lib/is_zsh.sh
@@ -1,0 +1,3 @@
+is_zsh() {
+  ps | grep zsh > /dev/null
+}

--- a/src/lib/is_zsh.sh
+++ b/src/lib/is_zsh.sh
@@ -1,3 +1,3 @@
 is_zsh() {
-  ps | grep zsh > /dev/null
+  pgrep zsh > /dev/null
 }

--- a/src/lib/is_zsh.sh
+++ b/src/lib/is_zsh.sh
@@ -1,3 +1,0 @@
-is_zsh() {
-  pgrep zsh > /dev/null
-}

--- a/test/approvals.bash
+++ b/test/approvals.bash
@@ -1,4 +1,4 @@
-# approvals.bash v0.2.6
+# approvals.bash v0.2.7
 #
 # Interactive approval testing for Bash.
 # https://github.com/DannyBen/approvals.bash
@@ -76,7 +76,7 @@ user_approval() {
 
   echo 
   printf "[A]pprove? \n"
-  read -r -n 1 response
+  response=$(bash -c "read -n 1 key; echo \$key")
   printf "\r"
   if [[ $response =~ [Aa] ]]; then
     printf "%b\n" "$actual" > "$approval_file"

--- a/test/approve_zsh
+++ b/test/approve_zsh
@@ -1,0 +1,15 @@
+#!/usr/bin/env zsh
+# Run this from the main repo directory
+
+source 'test/approvals.bash'
+
+unset ALF_RC_FILE
+export ALF_ALIASES_FILE="aliases.txt"
+
+describe "generated aliases in zsh"
+  pushd test/fixtures/generate > /dev/null
+  rm -f "aliases.txt"
+  approve "alf save"
+  source 'aliases.txt'
+  approve "say again zsh-works"
+  popd

--- a/test/approve_zsh
+++ b/test/approve_zsh
@@ -13,3 +13,5 @@ describe "generated aliases in zsh"
   source 'aliases.txt'
   approve "say again zsh-works"
   popd
+
+green "\nSanity test on ZSH passed!"

--- a/test/fixtures/generate/aliases.txt
+++ b/test/fixtures/generate/aliases.txt
@@ -87,7 +87,7 @@ dns() {
 }
 
 # Completions
-(ps | grep 217 | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit
+(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit
 complete -W "s l p" g
 complete -W "help" abc
 complete -W "again" say

--- a/test/fixtures/generate/aliases.txt
+++ b/test/fixtures/generate/aliases.txt
@@ -87,6 +87,7 @@ dns() {
 }
 
 # Completions
+(ps | grep 217 | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit
 complete -W "s l p" g
 complete -W "help" abc
 complete -W "again" say

--- a/test/fixtures/generate/aliases.txt
+++ b/test/fixtures/generate/aliases.txt
@@ -87,7 +87,7 @@ dns() {
 }
 
 # Completions
-(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit
+[[ -n $ZSH_VERSION ]] && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit
 complete -W "s l p" g
 complete -W "help" abc
 complete -W "again" say

--- a/test/fixtures/generate/approvals/alf_generate
+++ b/test/fixtures/generate/approvals/alf_generate
@@ -87,7 +87,7 @@ dns() {
 }
 
 # Completions
-(ps | grep 183 | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit
+(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit
 complete -W "s l p" g
 complete -W "help" abc
 complete -W "again" say

--- a/test/fixtures/generate/approvals/alf_generate
+++ b/test/fixtures/generate/approvals/alf_generate
@@ -87,6 +87,7 @@ dns() {
 }
 
 # Completions
+(ps | grep 183 | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit
 complete -W "s l p" g
 complete -W "help" abc
 complete -W "again" say

--- a/test/fixtures/generate/approvals/alf_generate
+++ b/test/fixtures/generate/approvals/alf_generate
@@ -87,7 +87,7 @@ dns() {
 }
 
 # Completions
-(ps | grep $$ | grep zsh > /dev/null) && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit
+[[ -n $ZSH_VERSION ]] && autoload -U +X compinit && compinit && autoload -U +X bashcompinit && bashcompinit
 complete -W "s l p" g
 complete -W "help" abc
 complete -W "again" say

--- a/test/fixtures/generate/approvals/say_again_zsh_works
+++ b/test/fixtures/generate/approvals/say_again_zsh_works
@@ -1,0 +1,1 @@
+zsh-works zsh-works


### PR DESCRIPTION
Closes #31

- [x] Implement
- [x] Current tests all pass
- [x] Add dockerized zsh tests
- [x] Verify it works in the real world
- [x] Update the README accordingly (also mention we still must have modern bash installed for alf to run in the first place, due to associative array use).