### PR TITLE
Fix post-save instructions in cases when ALF_ALIASES_FILE is set

### DIFF
--- a/alf
+++ b/alf
@@ -497,11 +497,13 @@ generate_last_cmd() {
 save_config() {
   find_config
 
+  friendly_aliases_file="${aliases_file/#$HOME/'~'}"
+
   echo "Saving to $aliases_file"
   generate_config > "$aliases_file"
 
   echo "To apply the new aliases to the current session, run:"
-  echo "$ source ~/.bash_aliases"
+  echo "$ source $friendly_aliases_file"
 }
 
 # :command.command_functions

--- a/src/lib/save_config.sh
+++ b/src/lib/save_config.sh
@@ -1,9 +1,11 @@
 save_config() {
   find_config
 
+  friendly_aliases_file="${aliases_file/#$HOME/'~'}"
+
   echo "Saving to $aliases_file"
   generate_config > "$aliases_file"
 
   echo "To apply the new aliases to the current session, run:"
-  echo "$ source ~/.bash_aliases"
+  echo "$ source $friendly_aliases_file"
 }

--- a/test/fixtures/generate/approvals/alf_save
+++ b/test/fixtures/generate/approvals/alf_save
@@ -1,3 +1,3 @@
 Saving to aliases.txt
 To apply the new aliases to the current session, run:
-$ source ~/.bash_aliases
+$ source aliases.txt


### PR DESCRIPTION
When `ALF_ALIASES_FILE` was set, the `alf save` instructed the user to still do `source ~/.bash_aliases` instead of using the value of the environment variable. This PR fixes it.