### PR TITLE
Remove call to zsh compinit

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,20 @@ should add this line to your startup script:
 source ~/.bash_aliases
 ```
 
+### ZSH Users
+
+Oh-My-Zsh users may skip this step.
+
+If you would like to have autocompletion for alf's sub-aliases and you are using
+zsh, you should enable completion by adding this to your `~/.zshrc` (if is it not
+already there) before sourcing `.bash_aliases`:
+
+```bash
+# Load completion functions
+autoload -Uz +X compinit && compinit
+autoload -Uz +X bashcompinit && bashcompinit
+```
+
 
 Related Projects
 --------------------------------------------------

--- a/alf
+++ b/alf
@@ -390,25 +390,13 @@ generate_completions() {
   find_config
 
   # shellcheck disable=SC2016
-  echo '
-# Enable bash completions in zsh
-if [[ -n ${ZSH_VERSION-} ]]; then
-  if ! command -v compinit > /dev/null; then
-    autoload -U +X compinit && if [[ ${ZSH_DISABLE_COMPFIX-} = true ]]; then
-      compinit -u
-    else
-      compinit
-    fi
-  fi
-  autoload -U +X bashcompinit && bashcompinit
-fi
-'
   echo '# Completions'
+  echo 'if command -v complete &> /dev/null ; then'
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ $line =~ $ali1_regex ]]; then
       ali="${BASH_REMATCH[1]}"
-      [[ -n $comp ]] && echo "complete -W $comp"
+      [[ -n $comp ]] && echo "  complete -W $comp"
       comps=""
       comp=""
     elif [[ $line =~ $ali2_regex ]]; then
@@ -422,8 +410,10 @@ fi
   done < "$config_file"
   
   if [[ -n $comp ]] && [[ -n $comps ]] ; then
-    echo "complete -W $comp"
+    echo "  complete -W $comp"
   fi
+  
+  echo 'fi'
 }
 
 # :src/lib/generate_config.sh

--- a/src/lib/generate_completion.sh
+++ b/src/lib/generate_completion.sh
@@ -4,25 +4,13 @@ generate_completions() {
   find_config
 
   # shellcheck disable=SC2016
-  echo '
-# Enable bash completions in zsh
-if [[ -n ${ZSH_VERSION-} ]]; then
-  if ! command -v compinit > /dev/null; then
-    autoload -U +X compinit && if [[ ${ZSH_DISABLE_COMPFIX-} = true ]]; then
-      compinit -u
-    else
-      compinit
-    fi
-  fi
-  autoload -U +X bashcompinit && bashcompinit
-fi
-'
   echo '# Completions'
+  echo 'if command -v complete &> /dev/null ; then'
 
   while IFS= read -r line || [ -n "$line" ]; do
     if [[ $line =~ $ali1_regex ]]; then
       ali="${BASH_REMATCH[1]}"
-      [[ -n $comp ]] && echo "complete -W $comp"
+      [[ -n $comp ]] && echo "  complete -W $comp"
       comps=""
       comp=""
     elif [[ $line =~ $ali2_regex ]]; then
@@ -36,7 +24,9 @@ fi
   done < "$config_file"
   
   if [[ -n $comp ]] && [[ -n $comps ]] ; then
-    echo "complete -W $comp"
+    echo "  complete -W $comp"
   fi
+  
+  echo 'fi'
 }
 

--- a/test/fixtures/generate/aliases.txt
+++ b/test/fixtures/generate/aliases.txt
@@ -86,22 +86,11 @@ dns() {
   fi
 }
 
-
-# Enable bash completions in zsh
-if [[ -n ${ZSH_VERSION-} ]]; then
-  if ! command -v compinit > /dev/null; then
-    autoload -U +X compinit && if [[ ${ZSH_DISABLE_COMPFIX-} = true ]]; then
-      compinit -u
-    else
-      compinit
-    fi
-  fi
-  autoload -U +X bashcompinit && bashcompinit
-fi
-
 # Completions
-complete -W "s l p" g
-complete -W "help" abc
-complete -W "again" say
-complete -W "ls deploy upd" dc
-complete -W "check flush" dns
+if command -v complete &> /dev/null ; then
+  complete -W "s l p" g
+  complete -W "help" abc
+  complete -W "again" say
+  complete -W "ls deploy upd" dc
+  complete -W "check flush" dns
+fi

--- a/test/fixtures/generate/approvals/alf_generate
+++ b/test/fixtures/generate/approvals/alf_generate
@@ -86,22 +86,11 @@ dns() {
   fi
 }
 
-
-# Enable bash completions in zsh
-if [[ -n ${ZSH_VERSION-} ]]; then
-  if ! command -v compinit > /dev/null; then
-    autoload -U +X compinit && if [[ ${ZSH_DISABLE_COMPFIX-} = true ]]; then
-      compinit -u
-    else
-      compinit
-    fi
-  fi
-  autoload -U +X bashcompinit && bashcompinit
-fi
-
 # Completions
-complete -W "s l p" g
-complete -W "help" abc
-complete -W "again" say
-complete -W "ls deploy upd" dc
-complete -W "check flush" dns
+if command -v complete &> /dev/null ; then
+  complete -W "s l p" g
+  complete -W "help" abc
+  complete -W "again" say
+  complete -W "ls deploy upd" dc
+  complete -W "check flush" dns
+fi


### PR DESCRIPTION
- [x] Remove calls to `compinit` and `bashcompinit` from the generated code.
- [x] Wrap all `complete` calls in generated code with a condition, checking if the `complete` command is available, to avoid ruining everything when it is not.
- [x] Add instructions in README for zsh users.

closes #41, closes #39