### PR TITLE
Support non-root installations via `PREFIX` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,20 @@
 Alf enhances your bash alias management. It was developed using the
 [Bashly Command Line Framework][bashly].
 
-
 ## Features
 
 - Create aliases by using a config file.
 - Create aliases for sub-commands (for example, `g s` for `git status`).
-- Synchronize your aliases across hosts or users by uploading your 
+- Synchronize your aliases across hosts or users by uploading your
   config file to GitHub.
 - Does not alter anything in your system except for creating the
   `~/.bash_aliases` file, which is normally already sourced by your login
   process.
 - Works with bash and zsh.
 
-
 ## Demo
 
 ![Demo](/demo/cast.gif)
-
 
 ## Installation
 
@@ -38,18 +35,24 @@ Install the `alf` executable script:
 $ curl -Ls get.dannyb.co/alf/setup | bash
 ```
 
+By default, alf is installed to `/usr/local`. To install to a different prefix
+(e.g. under your home directory to avoid needing `sudo`):
+
+```bash
+$ curl -Ls get.dannyb.co/alf/setup | PREFIX=~/.local bash
+```
+
 If you prefer to install manually, simply download the [alf](/alf) file,
 place it somewhere in your path, and make it executable.
 
 Note that alf requires bash 4.0 or higher (`brew install bash` for mac users).
 
-
 ## Using with GitHub-hosted configuration (recommended)
 
-The easiest way to use alf is to create a repository on github, call it 
+The easiest way to use alf is to create a repository on github, call it
 `alf-conf`, and put an `alf.conf` file in it.
 
-### 1. Create your own `alf-conf` repository  
+### 1. Create your own `alf-conf` repository
 
 - See the [alf.conf](alf.conf) file as a starting point, or
 - [Generate a template][template] from my [alf-conf][conf]
@@ -66,7 +69,6 @@ $ alf connect <your github user>
 $ alf save
 $ source ~/.bash_aliases  # this normally already exists in your ~/.bashrc
 ```
-
 
 ## Using without GitHub
 
@@ -126,14 +128,16 @@ Environment Variables:
 - [Sample, documented `alf.conf` file](alf.conf)
 - [`alf.conf(5)` man page](doc/alf.conf.md)
 
-
 ## Uninstalling
 
 To uninstall alf:
 
 ```shell
-# Run the uninstall script 
+# Run the uninstall script
 $ curl -Ls get.dannyb.co/alf/uninstall | bash
+
+# If you installed to a custom prefix, pass it here too
+$ curl -Ls get.dannyb.co/alf/uninstall | PREFIX=~/.local bash
 
 # Optionally, remove .alfrc (exists only if you have performed `alf connect`)
 $ rm -f ~/.alfrc
@@ -141,7 +145,6 @@ $ rm -f ~/.alfrc
 # Optionally, remove .bash_aliases (exists only if you have performed `alf save`)
 $ rm -f ~/.bash_aliases
 ```
-
 
 ## Compatibility
 
@@ -171,12 +174,10 @@ autoload -Uz +X compinit && compinit
 autoload -Uz +X bashcompinit && bashcompinit
 ```
 
-
 ## Related Projects
 
-For a similar project, but for command shortcuts on a per-directory basis, 
+For a similar project, but for command shortcuts on a per-directory basis,
 see [opcode][opcode].
-
 
 ## Contributing / Support
 

--- a/setup
+++ b/setup
@@ -19,6 +19,8 @@ section() {
   printf "\n=== %s\n" "$(green_bold "$@")"
 }
 
+prefix="${PREFIX:-/usr/local}"
+
 sudo_copy() {
   printf "%s => %s\n" "$(blue "$(printf '%-25s' "$1")")" "$2"
 
@@ -30,13 +32,17 @@ sudo_copy() {
 }
 
 copy_executable() {
-  sudo_copy "$1" "/usr/local/bin/" "755"
+  local bin_dir="$prefix/bin"
+  if [[ ! -d "$bin_dir" ]]; then
+    $sudo mkdir -p "$bin_dir"
+  fi
+  sudo_copy "$1" "$bin_dir/" "755"
 }
 
 copy_man() {
   for file in "$1"/*.[1-8]; do
     section="${file##*.}"
-    target_dir="/usr/local/share/man/man$section/"
+    target_dir="$prefix/share/man/man$section/"
 
     if [[ ! -d "$target_dir" ]]; then
       $sudo mkdir -p "$target_dir"
@@ -46,7 +52,7 @@ copy_man() {
   done
 
   if command_exist makewhatis; then
-    $sudo makewhatis /usr/local/man
+    $sudo makewhatis "$prefix/share/man"
   fi
 }
 
@@ -74,10 +80,14 @@ initialize() {
   set -e
   trap 'onerror' ERR
 
-  # Figure out if we need sudo or not
+  # Only use sudo if the prefix is not under the user's home directory
   sudo=''
   if [[ $EUID -ne 0 ]]; then
-    sudo='sudo'
+    if [[ -n "$HOME" && ( "$prefix" == "$HOME" || "$prefix" == "$HOME"/* ) ]]; then
+      :
+    else
+      sudo='sudo'
+    fi
   fi
 
   repo="$1"

--- a/uninstall
+++ b/uninstall
@@ -19,6 +19,8 @@ section() {
   printf "\n=== %s\n" "$(green_bold "$@")"
 }
 
+prefix="${PREFIX:-/usr/local}"
+
 command_exist() {
   [[ -x "$(command -v "$1")" ]]
 }
@@ -27,7 +29,7 @@ rm_executable() {
   if [[ -z "$1" ]]; then return; fi
 
   printf "%s %s\n" "$(blue rm)" "$1"
-  $sudo rm -f "/usr/local/bin/$1"
+  $sudo rm -f "$prefix/bin/$1"
 
   if command_exist "$1"; then
     fail "Command $1 still exists"
@@ -35,17 +37,17 @@ rm_executable() {
 }
 
 rm_man() {
-  if [[ ! -d "/usr/local/share/man/man1/" ]]; then return; fi
+  if [[ ! -d "$prefix/share/man/man1/" ]]; then return; fi
   if [[ -z "$1" ]]; then return; fi
 
-  printf "%s %s\n" "$(blue rm)" "/usr/local/share/man/man1/$1*.1"
-  $sudo rm -f /usr/local/share/man/man1/"$1"*.1
+  printf "%s %s\n" "$(blue rm)" "$prefix/share/man/man1/$1*.1"
+  $sudo rm -f "$prefix/share/man/man1/$1"*.1
 
-  printf "%s %s\n" "$(blue rm)" "/usr/local/share/man/man5/$1*.5"
-  $sudo rm -f /usr/local/share/man/man5/"$1"*.5
+  printf "%s %s\n" "$(blue rm)" "$prefix/share/man/man5/$1*.5"
+  $sudo rm -f "$prefix/share/man/man5/$1"*.5
 
   if command_exist makewhatis; then
-    $sudo makewhatis /usr/local/man
+    $sudo makewhatis "$prefix/share/man"
   fi
 }
 
@@ -64,10 +66,14 @@ initialize() {
   set -e
   trap 'onerror' ERR
 
-  # Figure out if we need sudo or not
+  # Only use sudo if the prefix is not under the user's home directory
   sudo=''
   if [[ $EUID -ne 0 ]]; then
-    sudo='sudo'
+    if [[ -n "$HOME" && ( "$prefix" == "$HOME" || "$prefix" == "$HOME"/* ) ]]; then
+      :
+    else
+      sudo='sudo'
+    fi
   fi
 }
 


### PR DESCRIPTION
### What
This PR introduces the `PREFIX` environment variable to the installation and uninstallation scripts, enabling users to install the tool without requiring elevated privileges.

### Why
Currently, the setup process hardcodes system-wide directories, which forcibly prompts for `sudo`. Many users either do not have root access on their environments or prefer to keep CLI tools isolated within user-owned directories. 

### How
- **Introduced PREFIX Variable:** The scripts now allow overriding the install directory via the `PREFIX` environment variable.
- **Dynamic Sudo Evaluation:** Added logic to check if the designated prefix is located within the user's home directory, safely bypassing sudo execution if elevation isn't needed.
- **Dynamic Manual Paths:** Ensured the manual page database command correctly targets the nested manual directory within the custom prefix, avoiding reliance on system-wide symlink structures.
- **Documentation:** Added instructions demonstrating how to use the new environment variable for non-elevated installations.
